### PR TITLE
Speak pipe integration

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -12,9 +12,13 @@ permalink: /contact/
             
             <div class="hline"></div>
                 <br>
-                If you like to contact us, please send us an e-mail or a message on Twitter.
+                If you like to contact us, please send us an <a href="mailto:{{site.email}}">e-mail</a> or a message on <a href="https://twitter.com/FLOSSforscience" target="new">Twitter</a>.
+            
+            <h4> Leave us an audio message
+                <iframe src="https://www.speakpipe.com/widget/inline/dxhuxmh65p1eqtdaffhvw34qltperi79" allow="microphone" width="100%" height="200" frameborder="0"></iframe>
+<script async src="https://www.speakpipe.com/widget/loader.js" charset="utf-8"></script>
                 
-             <h4>Contributing!</h4>
+            <h4>Contributing!</h4>
             
             <div class="hline"></div>
                 <br>

--- a/data.html
+++ b/data.html
@@ -19,6 +19,9 @@ permalink: /data/
  		<li>Downloads from the rss feeds are anonymously tracked with Blubrry's Podcast Statistics tool.
 			We collect aggregate anonymized data (such as downloads per episode, OS, Device Type and Country level location). 
  			For more details refer to Blubrry's <a href="https://create.blubrry.com/resources/about-blubrry/privacy-policy/">statement about data privacy</a>.</li>
+		<li>Audio messages are recorded and kept on <a href="https://www.speakpipe.com/">SpeakPipe's servers</a>. 
+			You can, optionnaly, give us your name and contact information. 
+ 			For more details refer to SpeakPipe's <a href="https://www.speakpipe.com/privacy">privacy policy</a>.</li>
 	     </ul> 
             
             <h3>Data usage</h3>
@@ -27,6 +30,10 @@ permalink: /data/
   		<li>We do not share or sell data to third parties.</li>
 	    	<li>The collected data is only used by us to improve the quality of our podcast. 
 			We are interested in the amount of listeners for each episode, so that we can adapt our content to our listeners needs.</li>
+		<li>Users sending us audio messages with SpeakPipe can, optionnaly, include their names and contact informations. 
+			These informations will only be used to contact you in return. 
+		     	We may, in the future, if you give us your consent, reuse some of these audio clips and informations in podcast episodes. 
+		     	</li>
 	     </ul> 
         </div>
     </div>


### PR DESCRIPTION
This branch will add the SpeakPipe embed recorder to our contact page and change "email" and "Twitter" to actual links. Appropriate information were also added to the Data privacy section of the website. 