### PR TITLE
I tunes 11 tags integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -94,6 +94,7 @@ podcast_url: https://flossforscience.github.io/
 podcast_album_art: https://raw.githubusercontent.com/FLOSSforScience/FLOSSforScience.github.io/master/assets/img/logo.png
 # podcast_album_art: /assets/img/logo.png
 podcast_title: FLOSS for Science
+podcast_type : episodic
 podcast_owner: FLOSSforScience
 podcast_email: flossforscience@gmail.com 
 podcast_category: Technology

--- a/_posts/2018-01-03-season-1-episode-1.markdown
+++ b/_posts/2018-01-03-season-1-episode-1.markdown
@@ -16,6 +16,7 @@ podcast_duration: "10:48"
 podcast_length: 5220352
 podcast_length_ogg: 4043062
 podcast_guid: 454393ac623ec4173b3a93c0bb2d943b2f81074979185bf8c4350cd9812c2677
+podcast_episode_type: full
 podcast_subtitle: Content and aims of the podcast.
 podcast_description: In this episode the two hosts David Brassard and Patrick Diehl of FLOSS for Science introduce themselves and they explain the aims of this podcast.
 ---

--- a/_posts/2018-01-03-season-1-episode-1.markdown
+++ b/_posts/2018-01-03-season-1-episode-1.markdown
@@ -17,6 +17,7 @@ podcast_length: 5220352
 podcast_length_ogg: 4043062
 podcast_guid: 454393ac623ec4173b3a93c0bb2d943b2f81074979185bf8c4350cd9812c2677
 podcast_episode_type: full
+podcast_episode_number: 001
 podcast_subtitle: Content and aims of the podcast.
 podcast_description: In this episode the two hosts David Brassard and Patrick Diehl of FLOSS for Science introduce themselves and they explain the aims of this podcast.
 ---

--- a/_posts/2018-01-03-season-1-episode-1.markdown
+++ b/_posts/2018-01-03-season-1-episode-1.markdown
@@ -19,6 +19,8 @@ podcast_length: 5220352
 podcast_length_ogg: 4043062
 podcast_guid: 454393ac623ec4173b3a93c0bb2d943b2f81074979185bf8c4350cd9812c2677
 podcast_episode_type: full
+#Season number only
+podcast_season_number: 01
 podcast_episode_number: 001
 podcast_subtitle: Content and aims of the podcast.
 podcast_description: In this episode the two hosts David Brassard and Patrick Diehl of FLOSS for Science introduce themselves and they explain the aims of this podcast.

--- a/_posts/2018-01-03-season-1-episode-1.markdown
+++ b/_posts/2018-01-03-season-1-episode-1.markdown
@@ -1,11 +1,13 @@
 ---
 layout: post
-title: "001: Introduction to the FLOSS for Science podcast"
+title: "EP001 Introduction to the FLOSS for Science podcast"
 date: 2018-01-12 13:59:59
 author: Admin
 categories: 
  - podcast 
 #- blog 
+#Title of the podcast episode without the episode number
+podcast_episode_title: Introduction to the FLOSS for Science podcast
 img: FFS001_header.png
 thumb: FFS001_thumb.png
 podcast_link: https://media.blubrry.com/flossforscience/archive.org/download/FlossforscienceEp001-Introduction/FlossforscienceEp001-Introduction.mp3

--- a/_posts/2018-02-07-season-1-episode-2.markdown
+++ b/_posts/2018-02-07-season-1-episode-2.markdown
@@ -20,6 +20,8 @@ podcast_length: 14302230
 podcast_length_ogg: 11483928
 podcast_guid: 204efffe623ab7cc39e821a46fc39a6062ff44cd8413d4d8a4ef730e275dbb5b
 podcast_episode_type: full
+#Season number only
+podcast_season_number: 01
 podcast_episode_number: 002
 podcast_subtitle: An interview with Laurent Cormier
 podcast_description: In Episode 2, we interview Laurent Cormier, a research associate at the Ecole de Technologie Superieure in Montreal. He introduces us to his past research regarding the evaluation of the fatigue life of composite materials and the predictive model he developped with Python. He also share with us his scientific perspective on FLOSS and tools he uses in his research workflow.

--- a/_posts/2018-02-07-season-1-episode-2.markdown
+++ b/_posts/2018-02-07-season-1-episode-2.markdown
@@ -17,6 +17,7 @@ podcast_duration: "10:48"
 podcast_length: 14302230
 podcast_length_ogg: 11483928
 podcast_guid: 204efffe623ab7cc39e821a46fc39a6062ff44cd8413d4d8a4ef730e275dbb5b
+podcast_episode_type: full
 podcast_subtitle: An interview with Laurent Cormier
 podcast_description: In Episode 2, we interview Laurent Cormier, a research associate at the Ecole de Technologie Superieure in Montreal. He introduces us to his past research regarding the evaluation of the fatigue life of composite materials and the predictive model he developped with Python. He also share with us his scientific perspective on FLOSS and tools he uses in his research workflow.
 ---

--- a/_posts/2018-02-07-season-1-episode-2.markdown
+++ b/_posts/2018-02-07-season-1-episode-2.markdown
@@ -1,12 +1,14 @@
 ---
 layout: post
-title: "002: Modeling composite materials fatigue with Python"
+title: "EP002 Modeling composite materials fatigue with Python"
 date: 2018-02-07 01:00:00
 author: Admin
 categories: 
  - podcast
  - user
 #- blog 
+#Title of the podcast episode without the episode number
+podcast_episode_title: Modeling composite materials fatigue with Python
 img: FFS002_header.png
 thumb: FFS002_thumb.png
 podcast_link: http://media.blubrry.com/flossforscience/archive.org/download/FlossforscienceEp002-ModelingCompositeMaterialsFatigueWithPython/FlossforscienceEp002.mp3

--- a/_posts/2018-02-07-season-1-episode-2.markdown
+++ b/_posts/2018-02-07-season-1-episode-2.markdown
@@ -18,6 +18,7 @@ podcast_length: 14302230
 podcast_length_ogg: 11483928
 podcast_guid: 204efffe623ab7cc39e821a46fc39a6062ff44cd8413d4d8a4ef730e275dbb5b
 podcast_episode_type: full
+podcast_episode_number: 002
 podcast_subtitle: An interview with Laurent Cormier
 podcast_description: In Episode 2, we interview Laurent Cormier, a research associate at the Ecole de Technologie Superieure in Montreal. He introduces us to his past research regarding the evaluation of the fatigue life of composite materials and the predictive model he developped with Python. He also share with us his scientific perspective on FLOSS and tools he uses in his research workflow.
 ---

--- a/_posts/2018-02-07-season-1-episode-3.markdown
+++ b/_posts/2018-02-07-season-1-episode-3.markdown
@@ -16,6 +16,7 @@ podcast_duration: "39:56"
 podcast_length: 19376128
 podcast_length_ogg: 16166766
 podcast_guid: 484fa7cf99b4c64e8f169743dca41b59cf621def
+podcast_episode_type: full
 podcast_subtitle: An interview with Oliver Kopp and Jörg Lenhard
 podcast_description: In Episode 3, we interview Oliver Kopp and Jörg Lenhard about the reference management tool Jabref.
 ---

--- a/_posts/2018-02-07-season-1-episode-3.markdown
+++ b/_posts/2018-02-07-season-1-episode-3.markdown
@@ -6,6 +6,8 @@ author: Admin
 categories: 
  - developer 
  - podcast
+#Title of the podcast episode without the episode number
+podcast_episode_title: JabRef at JabCon
 img: FFS003_header.png
 thumb: FFS003_thumb.png
 podcast_link: http://media.blubrry.com/flossforscience/archive.org/download/Flossforscience-Ep003JabrefAtJabcon/FlossforscienceEp003.mp3

--- a/_posts/2018-02-07-season-1-episode-3.markdown
+++ b/_posts/2018-02-07-season-1-episode-3.markdown
@@ -19,6 +19,8 @@ podcast_length: 19376128
 podcast_length_ogg: 16166766
 podcast_guid: 484fa7cf99b4c64e8f169743dca41b59cf621def
 podcast_episode_type: full
+#Season number only
+podcast_season_number: 01
 podcast_episode_number: 003
 podcast_subtitle: An interview with Oliver Kopp and Jörg Lenhard
 podcast_description: In Episode 3, we interview Oliver Kopp and Jörg Lenhard about the reference management tool Jabref.

--- a/_posts/2018-02-07-season-1-episode-3.markdown
+++ b/_posts/2018-02-07-season-1-episode-3.markdown
@@ -17,6 +17,7 @@ podcast_length: 19376128
 podcast_length_ogg: 16166766
 podcast_guid: 484fa7cf99b4c64e8f169743dca41b59cf621def
 podcast_episode_type: full
+podcast_episode_number: 003
 podcast_subtitle: An interview with Oliver Kopp and Jörg Lenhard
 podcast_description: In Episode 3, we interview Oliver Kopp and Jörg Lenhard about the reference management tool Jabref.
 ---

--- a/_posts/2018-03-25-season-1-episode-4.markdown
+++ b/_posts/2018-03-25-season-1-episode-4.markdown
@@ -28,6 +28,8 @@ podcast_length_ogg: 17821879
 podcast_guid: a6e6624d95f6c9d7ca3f8687f467bb703e4e92ec6c0414dc6fb849850f302292
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Episode number only
+podcast_episode_number: 004
 #Subtitle of the episode 
 podcast_subtitle: An interview with Carl Boettinger
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-4.markdown
+++ b/_posts/2018-03-25-season-1-episode-4.markdown
@@ -26,6 +26,8 @@ podcast_length: 19212188
 podcast_length_ogg: 17821879
 #Unique id of the mp3 file (sha256)
 podcast_guid: a6e6624d95f6c9d7ca3f8687f467bb703e4e92ec6c0414dc6fb849850f302292
+#“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
+podcast_episode_type: full
 #Subtitle of the episode 
 podcast_subtitle: An interview with Carl Boettinger
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-4.markdown
+++ b/_posts/2018-03-25-season-1-episode-4.markdown
@@ -30,6 +30,8 @@ podcast_length_ogg: 17821879
 podcast_guid: a6e6624d95f6c9d7ca3f8687f467bb703e4e92ec6c0414dc6fb849850f302292
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Season number only
+podcast_season_number: 01
 #Episode number only
 podcast_episode_number: 004
 #Subtitle of the episode 

--- a/_posts/2018-03-25-season-1-episode-4.markdown
+++ b/_posts/2018-03-25-season-1-episode-4.markdown
@@ -6,6 +6,8 @@ author: Admin
 categories: 
  - user
  - podcast
+#Title of the podcast episode without the episode number
+podcast_episode_title: Reproducible science with Rocker
 #Image of the blog post
 img: FFS004_header.png
 #Thumbnail of the blog post

--- a/_posts/2018-03-25-season-1-episode-5.markdown
+++ b/_posts/2018-03-25-season-1-episode-5.markdown
@@ -30,6 +30,8 @@ podcast_length_ogg: 13329533
 podcast_guid: f8ecf0a788a3c7e9402656d74ffcd0eaa44f0d36d93294dc056a57353ae8e712
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Season number only
+podcast_season_number: 01
 #Episode number only
 podcast_episode_number: 005
 #Subtitle of the episode 

--- a/_posts/2018-03-25-season-1-episode-5.markdown
+++ b/_posts/2018-03-25-season-1-episode-5.markdown
@@ -6,6 +6,8 @@ author: Admin
 categories: 
  - developer
  - podcast
+#Title of the podcast episode without the episode number
+podcast_episode_title: LibreOffice the Swiss Army Knife of Science?
 #Image of the blog post
 img: FFS005_header.png
 #Thumbnail of the blog post

--- a/_posts/2018-03-25-season-1-episode-5.markdown
+++ b/_posts/2018-03-25-season-1-episode-5.markdown
@@ -28,6 +28,8 @@ podcast_length_ogg: 13329533
 podcast_guid: f8ecf0a788a3c7e9402656d74ffcd0eaa44f0d36d93294dc056a57353ae8e712
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Episode number only
+podcast_episode_number: 005
 #Subtitle of the episode 
 podcast_subtitle: An interview with Katarina Behrens
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-5.markdown
+++ b/_posts/2018-03-25-season-1-episode-5.markdown
@@ -26,6 +26,8 @@ podcast_length: 14309138
 podcast_length_ogg: 13329533
 #Unique id of the mp3 file (sha255)
 podcast_guid: f8ecf0a788a3c7e9402656d74ffcd0eaa44f0d36d93294dc056a57353ae8e712
+#“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
+podcast_episode_type: full
 #Subtitle of the episode 
 podcast_subtitle: An interview with Katarina Behrens
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-6.markdown
+++ b/_posts/2018-03-25-season-1-episode-6.markdown
@@ -26,6 +26,8 @@ podcast_length: 28190601
 podcast_length_ogg: 29312716
 #Unique id of the mp3 file (sha255)
 podcast_guid: a45d9910f8db37ff0a74eccc23a8c7e61600e39cada36a1dab6387e198cad3f4
+#“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
+podcast_episode_type: full
 #Subtitle of the episode 
 podcast_subtitle: An interview with Christian horea
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-6.markdown
+++ b/_posts/2018-03-25-season-1-episode-6.markdown
@@ -28,6 +28,8 @@ podcast_length_ogg: 29312716
 podcast_guid: a45d9910f8db37ff0a74eccc23a8c7e61600e39cada36a1dab6387e198cad3f4
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Episode number only
+podcast_episode_number: 006
 #Subtitle of the episode 
 podcast_subtitle: An interview with Christian horea
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-6.markdown
+++ b/_posts/2018-03-25-season-1-episode-6.markdown
@@ -6,6 +6,8 @@ author: Admin
 categories: 
  - developer
  - podcast
+#Title of the podcast episode without the episode number
+podcast_episode_title: Gentoo Linux for Neurosciences
 #Image of the blog post
 img: FFS006_header.png
 #Thumbnail of the blog post

--- a/_posts/2018-03-25-season-1-episode-6.markdown
+++ b/_posts/2018-03-25-season-1-episode-6.markdown
@@ -30,6 +30,8 @@ podcast_length_ogg: 29312716
 podcast_guid: a45d9910f8db37ff0a74eccc23a8c7e61600e39cada36a1dab6387e198cad3f4
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Season number only
+podcast_season_number: 01
 #Episode number only
 podcast_episode_number: 006
 #Subtitle of the episode 

--- a/_posts/2018-03-25-season-1-episode-7.markdown
+++ b/_posts/2018-03-25-season-1-episode-7.markdown
@@ -6,6 +6,8 @@ author: Admin
 categories: 
  - undefined
  - podcast
+#Title of the podcast episode without the episode number
+podcast_episode_title: A Guide to Software Licenses in Science
 #Image of the blog post
 img: FFS007_header.png
 #Thumbnail of the blog post

--- a/_posts/2018-03-25-season-1-episode-7.markdown
+++ b/_posts/2018-03-25-season-1-episode-7.markdown
@@ -26,6 +26,8 @@ podcast_length: 29600303
 podcast_length_ogg: 30377951
 #Unique id of the mp3 file (sha256)
 podcast_guid: 1ed15f75ba274b68beb6860ce566521590c2a2c0861f614574c37b7b9ccca513
+#“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
+podcast_episode_type: full
 #Subtitle of the episode 
 podcast_subtitle: An interview with Karl Fogel and James Vasile
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-7.markdown
+++ b/_posts/2018-03-25-season-1-episode-7.markdown
@@ -28,6 +28,8 @@ podcast_length_ogg: 30377951
 podcast_guid: 1ed15f75ba274b68beb6860ce566521590c2a2c0861f614574c37b7b9ccca513
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Episode number only
+podcast_episode_number: 007
 #Subtitle of the episode 
 podcast_subtitle: An interview with Karl Fogel and James Vasile
 #Description of the podcast

--- a/_posts/2018-03-25-season-1-episode-7.markdown
+++ b/_posts/2018-03-25-season-1-episode-7.markdown
@@ -30,6 +30,8 @@ podcast_length_ogg: 30377951
 podcast_guid: 1ed15f75ba274b68beb6860ce566521590c2a2c0861f614574c37b7b9ccca513
 #“full” for normal episodes; “trailer” to promote an upcoming show, season, or episode; or “bonus” for extra content related to a show, season, or episode.
 podcast_episode_type: full
+#Season number only
+podcast_season_number: 01
 #Episode number only
 podcast_episode_number: 007
 #Subtitle of the episode 

--- a/feed.xml
+++ b/feed.xml
@@ -24,6 +24,7 @@ xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
 <itunes:summary>{{ site.podcast_summary }}</itunes:summary>
 <itunes:author>{{ site.podcast_author }}</itunes:author>
 <itunes:explicit>{{ site.podcast_explicit }}</itunes:explicit>
+<itunes:type>{{ site.podcast_type }}</itunes:type>
 <!-- <itunes:image href="{{ site.url }}{{ site.podcast_album_art }}" /> -->
 <itunes:image href="{{ site.podcast_album_art }}" />
 <itunes:owner>
@@ -69,6 +70,7 @@ xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
     <itunes:image href="{{ site.podcast_album_art }}" />
     <itunes:explicit>{{ site.podcast_explicit }}</itunes:explicit>
     <itunes:duration>{{ ep.podcast_duration }}</itunes:duration>
+	<itunes:episodeType>{{ ep.podcast_episode_type }}</itunes:episodeType>
   </item>
 {% endfor %}
 </channel>

--- a/feed.xml
+++ b/feed.xml
@@ -64,7 +64,8 @@ xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
     </content:encoded>
 
     <enclosure url="{{ ep.podcast_link }}" length="{{ ep.podcast_length }}" type="audio/mpeg" />
-    <itunes:subtitle>{{ ep.podcast_subtitle }}</itunes:subtitle>
+    <itunes:episode>{{ podcast_episode_number }}</itunes:episode>
+	<itunes:subtitle>{{ ep.podcast_subtitle }}</itunes:subtitle>
     <itunes:summary>{{ ep.podcast_description }}</itunes:summary>
     <itunes:author>{{ site.podcast_author }}</itunes:author>
     <itunes:image href="{{ site.podcast_album_art }}" />

--- a/feed.xml
+++ b/feed.xml
@@ -64,7 +64,8 @@ xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
     </content:encoded>
 
     <enclosure url="{{ ep.podcast_link }}" length="{{ ep.podcast_length }}" type="audio/mpeg" />
-    <itunes:episode>{{ podcast_episode_number }}</itunes:episode>
+    <itunes:season>{{ ep.podcast_season_number }}</itunes:season>
+	<itunes:episode>{{ podcast_episode_number }}</itunes:episode>
 	<itunes:title>{{ ep.podcast_episode_title }}</itunes:title>
 	<itunes:subtitle>{{ ep.podcast_subtitle }}</itunes:subtitle>
     <itunes:summary>{{ ep.podcast_description }}</itunes:summary>

--- a/feed.xml
+++ b/feed.xml
@@ -65,6 +65,7 @@ xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
 
     <enclosure url="{{ ep.podcast_link }}" length="{{ ep.podcast_length }}" type="audio/mpeg" />
     <itunes:episode>{{ podcast_episode_number }}</itunes:episode>
+	<itunes:title>{{ ep.podcast_episode_title }}</itunes:title>
 	<itunes:subtitle>{{ ep.podcast_subtitle }}</itunes:subtitle>
     <itunes:summary>{{ ep.podcast_description }}</itunes:summary>
     <itunes:author>{{ site.podcast_author }}</itunes:author>


### PR DESCRIPTION
Request to merge the new iTunes 11 RSS tags. I also edited episode 1 to 7 to add the relevant info. 

The title of EP001 and EP002 where also slightly changed to uniformize them. This should not trigger a redownload of the episodes. 

show/channel level

	<itunes:type> episodic

episode/item level

	<itunes:episodeType> full/bonus/trailer
	<itunes:title> Only the episode title
	<itunes:episode> XXX
	<itunes:season> 01
